### PR TITLE
Enhance `cryosieve_auto_cryosparc.py` with New Command-Line Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,18 +249,21 @@ There are several useful remarks:
 The `cryosieve_auto_cryosparc.py` is a Python script designed to automatically and sequentially execute a series of operations in CryoSPARC, namely `import particle stack`, `ab-initio`, `homogenous refinement`, and `non-uniform refinement` jobs.
 
 ```
-usage: cryosieve_auto_cryosparc.py [-h] [--particles_sheet PARTICLES_SHEET] [--cryosparc_user_id CRYOSPARC_USER_ID]
-                                   [--cryosparc_project_uid CRYOSPARC_PROJECT_UID] [--cryosparc_workspace_uid CRYOSPARC_WORKSPACE_UID]
-                                   [--cryosparc_lane CRYOSPARC_LANE] [--molecular_symmetry MOLECULAR_SYMMETRY]
+usage: cryosieve_auto_cryosparc.py [-h] --particles_sheet PARTICLES_SHEET --cryosparc_user_id CRYOSPARC_USER_ID
+                                   --cryosparc_project_uid CRYOSPARC_PROJECT_UID --cryosparc_workspace_uid
+                                   CRYOSPARC_WORKSPACE_UID --cryosparc_lane CRYOSPARC_LANE
+                                   [--molecular_symmetry MOLECULAR_SYMMETRY] [--force_redo_gs_split]
+                                   [--num_repeats_homo NUM_REPEATS_HOMO]
+                                   [--num_repeats_nonuniform NUM_REPEATS_NONUNIFORM]
 
-The cryosieve_auto_cryosparc.py is a Python script designed to automate CryoSPARC operations via the command line. Its purpose is to
-bypass the labor-intensive manual processes.
+The cryosieve_auto_cryosparc.py is a Python script designed to automate CryoSPARC operations via the command line.
+Its purpose is to bypass the labor-intensive manual processes.
 
-options:
+optional arguments:
   -h, --help            show this help message and exit
   --particles_sheet PARTICLES_SHEET
-                        a file containing a list of starfiles; each starfile corresponds to a single-particle dataset; NOTE, absolute
-                        directory is mandatory
+                        a file containing a list of starfiles; each starfile corresponds to a single-particle
+                        dataset; NOTE, absolute directory is mandatory
   --cryosparc_user_id CRYOSPARC_USER_ID
                         the E-mail address of the user of CryoSPARC
   --cryosparc_project_uid CRYOSPARC_PROJECT_UID
@@ -270,5 +273,11 @@ options:
   --cryosparc_lane CRYOSPARC_LANE
                         the lane for computing resource in cryoSPARC
   --molecular_symmetry MOLECULAR_SYMMETRY
-                        molecular symmetry
+                        molecular symmetry, default: C1
+  --force_redo_gs_split
+                        force re-do GS split
+  --num_repeats_homo NUM_REPEATS_HOMO
+                        number of repeats for running homogenous refinement, default: 1
+  --num_repeats_nonuniform NUM_REPEATS_NONUNIFORM
+                        number of repeats for running non-uniform refinement, default: 1
 ```


### PR DESCRIPTION
This pull request introduces three new command-line options to `incryosieve_auto_cryosparc.py`, aimed at extending the script's capabilities and providing users with additional operational flexibility. The newly added options are as follows:

- `--force_redo_gs_split`: Force re-do GS split.
- `--num_repeats_homo NUM_REPEATS_HOMO`: Sets the number of repeats for running homogeneous refinement, with a default value of 1.
- `--num_repeats_nonuniform NUM_REPEATS_NONUNIFORM`: Specifies the number of repeats for running non-uniform refinement, also defaulting to 1.

These enhancements allow users to have greater control over specific steps in the processing pipeline, catering to advanced use cases and optimization needs.