### PR TITLE
Add release checklist and job progress logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ next.md
 README.pdf
 README.tex
 .arcconfig
+CLAUDE.md

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -1,0 +1,102 @@
+# Release Checklist
+
+This document captures the release workflow used for this repository.
+
+## 1. Confirm the version
+
+Before tagging, make sure the version is updated consistently:
+
+- `pyproject.toml`
+- `src/cryosieve/__init__.py`
+
+## 2. Confirm the target commit
+
+Check that the release should be cut from the intended commit and that the working tree is in the expected state.
+
+Useful commands:
+
+```bash
+git status --short
+git log --oneline --decorate -5
+git rev-parse HEAD
+```
+
+## 3. Check whether the tag or release already exists
+
+```bash
+git tag -l "vX.Y.Z"
+git ls-remote --tags origin "vX.Y.Z"
+gh release view "vX.Y.Z" --repo mxhulab/cryosieve
+```
+
+## 4. Make sure GitHub CLI is ready
+
+If needed:
+
+```bash
+brew install gh
+gh auth login
+gh auth status
+```
+
+## 5. Create and push the tag
+
+Tag the intended commit, then push it:
+
+```bash
+git tag "vX.Y.Z" <commit>
+git push origin "vX.Y.Z"
+```
+
+If the release should point at the current `HEAD`, use that commit explicitly or tag `HEAD` after verifying it is correct.
+
+## 6. Create the GitHub Release
+
+This repository publishes to PyPI from `.github/workflows/pippublish.yml`, and that workflow is triggered by the GitHub `release.published` event.
+
+That means:
+
+- pushing the tag is not enough
+- the GitHub Release must also be created/published
+
+Example:
+
+```bash
+gh release create "vX.Y.Z" \
+  --repo mxhulab/cryosieve \
+  --title "vX.Y.Z" \
+  --generate-notes
+```
+
+## 7. Rewrite the release notes
+
+Do not leave the release notes as a raw auto-generated engineering changelog.
+
+Preferred tone for this repository:
+
+- user-facing
+- cryo-EM / paper-adjacent
+- focused on practical impact
+
+Emphasize:
+
+- what users will notice
+- installation or environment updates
+- runtime / workflow improvements
+- downstream analysis changes
+- compatibility notes when results may differ slightly from older versions
+
+## 8. Verify the published release
+
+After publishing:
+
+- open the GitHub release page
+- confirm the title, tag, and notes are correct
+- confirm the PyPI publish workflow has started or completed
+
+Useful commands:
+
+```bash
+gh release view "vX.Y.Z" --repo mxhulab/cryosieve
+gh run list --repo mxhulab/cryosieve --workflow pippublish.yml
+```

--- a/src/cryosieve/cs_refine.py
+++ b/src/cryosieve/cs_refine.py
@@ -1,5 +1,7 @@
 import argparse
 import csv
+import logging
+import logging.config
 import os
 import re
 import subprocess
@@ -10,6 +12,37 @@ from concurrent.futures import ThreadPoolExecutor
 from threading import Lock
 from time import sleep
 from random import uniform
+
+logging.config.dictConfig({
+    'version': 1,
+    'disable_existing_loggers': False,
+    'formatters': {
+        'standard': {
+            'format': '[%(asctime)s][%(levelname)s] %(message)s',
+            'datefmt': r'%Y-%m-%d %H:%M:%S'
+        },
+    },
+    'handlers': {
+        'file': {
+            'level': 'INFO',
+            'formatter': 'standard',
+            'class': 'logging.FileHandler',
+            'filename': 'cryosieve.log',
+        },
+    },
+    'loggers': {
+        'CryoSieve': {
+            'level': 'INFO',
+            'handlers': ['file'],
+            'propagate': False
+        }
+    }
+})
+logger = logging.getLogger('CryoSieve')
+cryosparc_job_total = None
+cryosparc_jobs_generated = 0
+cryosparc_jobs_enqueued = 0
+cryosparc_jobs_completed = 0
 
 def parse_argument():
     parser = argparse.ArgumentParser(description = 'cryosieve-csrefine: automatic SPA 3D-refinement by calling CryoSPARC')
@@ -48,6 +81,9 @@ def load_cryosparc(args):
     lock = Lock()
 
 def enqueue_and_wait(local_lane, **kwargs):
+    global cryosparc_jobs_generated, cryosparc_jobs_enqueued, cryosparc_jobs_completed
+    job_type = kwargs.get('job_type', 'unknown')
+
     with lock:
         job_id = client.make_job(
             user_id = user_id,
@@ -55,15 +91,24 @@ def enqueue_and_wait(local_lane, **kwargs):
             workspace_uid = workspace_uid,
             **kwargs
         )
+        cryosparc_jobs_generated += 1
+        logger.info(f'Generated CryoSPARC job {job_id} ({job_type}, {cryosparc_jobs_generated}/{cryosparc_job_total})')
+
         client.enqueue_job(project_uid, job_id, local_lane, user_id)
+        cryosparc_jobs_enqueued += 1
+        logger.info(f'Enqueued CryoSPARC job {job_id} ({job_type}, lane={local_lane}, {cryosparc_jobs_enqueued}/{cryosparc_job_total})')
 
     while True:
         sleep(uniform(20, 40))
-        with lock: job_status = client.get_job_status(project_uid, job_id)
-        if job_status == 'completed':
-            return job_id
-        elif job_status in ['failed', 'killed']:
-            raise RuntimeError(f'Job {job_id} is {job_status}')
+        with lock:
+            job_status = client.get_job_status(project_uid, job_id)
+            if job_status == 'completed':
+                cryosparc_jobs_completed += 1
+                logger.info(f'Completed CryoSPARC job {job_id} ({job_type}, {cryosparc_jobs_completed}/{cryosparc_job_total})')
+                return job_id
+            elif job_status in ['failed', 'killed']:
+                logger.error(f'CryoSPARC job {job_id} {job_status} ({job_type}, completed={cryosparc_jobs_completed}/{cryosparc_job_total})')
+                raise RuntimeError(f'Job {job_id} is {job_status}')
 
 def import_particles(particle_meta_path):
     import_job_id = enqueue_and_wait(
@@ -139,7 +184,7 @@ def parse_result(refine_job_id):
 
 def check_results(results, info = None):
     if info is not None:
-        print(info, results)
+        logger.info(f'{info} {results}')
     if any(result is None for result in results):
         raise RuntimeError('Error occurred during execution')
 
@@ -163,6 +208,15 @@ def main():
               ('--resplit ' if args.resplit else '') + \
               (f'--workers {args.workers} ' if args.workers is not None else '')
     subprocess.run(command, shell = True)
+
+def calculate_cryosparc_job_counts(num_particle_meta_paths):
+    return {
+        'import_particles' : num_particle_meta_paths,
+        'import_volumes' : 1 if args.ref is not None else 0,
+        'homo_abinit' : 0 if args.ref is not None else num_particle_meta_paths,
+        'refine' : num_particle_meta_paths * args.repeat,
+        'local_refine' : num_particle_meta_paths * args.repeat if args.local else 0
+    }
 
 def parse_meta_paths(paths):
     particle_meta_paths = []
@@ -192,6 +246,19 @@ if __name__ == '__main__':
     if args.ref is not None:
         if not Path(args.ref).is_file():
             raise FileNotFoundError(f'"{args.ref}" does not exist')
+
+    cryosparc_job_counts = calculate_cryosparc_job_counts(len(particle_meta_paths))
+    cryosparc_job_total = sum(cryosparc_job_counts.values())
+    logger.info(
+        f'Planned CryoSPARC jobs: total={cryosparc_job_total}, '
+        f'import_particles={cryosparc_job_counts["import_particles"]}, '
+        f'import_volumes={cryosparc_job_counts["import_volumes"]}, '
+        f'homo_abinit={cryosparc_job_counts["homo_abinit"]}, '
+        f'refine={cryosparc_job_counts["refine"]}, '
+        f'local_refine={cryosparc_job_counts["local_refine"]}, '
+        f'particle inputs={len(particle_meta_paths)}, repeat={args.repeat}, '
+        f'ref={args.ref is not None}, local={args.local}'
+    )
 
     # Setup.
     pool = ThreadPoolExecutor() if args.workers is None else ThreadPoolExecutor(max_workers = args.workers)


### PR DESCRIPTION
## Summary
- Add a release checklist documenting the tag-first, GitHub Release-triggered PyPI publish flow.
- Ignore local `CLAUDE.md` files to avoid committing workspace-specific Claude Code guidance.
- Update `cryosieve-csrefine` to write progress logs to `cryosieve.log`, including planned CryoSPARC job counts and per-job generated/enqueued/completed events.

## Test plan
- `python -m py_compile src/cryosieve/cs_refine.py`
- `git diff --check -- src/cryosieve/cs_refine.py`