### PR TITLE
automatic cryosparc client without cryosparcm env

### DIFF
--- a/src/cryosieve/autocsparc/__init__.py
+++ b/src/cryosieve/autocsparc/__init__.py
@@ -1,0 +1,13 @@
+"""
+Lightweight client for CryoSPARC command_core JSON-RPC APIs.
+
+The package intentionally depends only on Python's standard library. It is
+designed for small automation scripts that need to talk to a running
+CryoSPARC command_core service.
+"""
+
+from .client import CommandClient
+from .dryrun import DryRunClient
+from .errors import CommandError
+
+__all__ = ["CommandClient", "DryRunClient", "CommandError"]

--- a/src/cryosieve/autocsparc/client.py
+++ b/src/cryosieve/autocsparc/client.py
@@ -1,0 +1,325 @@
+"""
+Core-only CryoSPARC command client.
+
+This module implements a small JSON-RPC 2.0 client for CryoSPARC's
+``command_core`` service. It intentionally uses only Python's standard library:
+
+* ``urllib`` for HTTP
+* ``json`` for JSON serialization
+* ``uuid`` for JSON-RPC request IDs
+
+Typical usage:
+
+    from autocsparc import CommandClient
+
+    cli = CommandClient()
+
+    print(cli.get_system_info())
+    print(cli.call("list_projects"))
+
+The client calls ``system.describe`` at initialization and creates dynamic
+methods for each exposed JSON-RPC endpoint. If ``host``, ``port`` or
+``license_id`` are not passed explicitly, the client reads
+``CRYOSPARC_MASTER_HOSTNAME``, ``CRYOSPARC_COMMAND_CORE_PORT`` and
+``CRYOSPARC_LICENSE_ID`` from the current environment, falling back to
+``cryosparcm env`` when necessary. ``host`` and ``port`` must be provided either
+explicitly or through the CryoSPARC environment.
+"""
+
+import json
+import socket
+import time
+import uuid
+from typing import Any, Dict, List, Optional
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+from warnings import warn
+
+from .env import (
+    get_env,
+    get_env_int,
+    get_env_value,
+)
+from .errors import CommandError
+
+
+SERVICE_NAME = "command_core"
+ENV_MASTER_HOSTNAME = "CRYOSPARC_MASTER_HOSTNAME"
+ENV_COMMAND_CORE_PORT = "CRYOSPARC_COMMAND_CORE_PORT"
+ENV_LICENSE_ID = "CRYOSPARC_LICENSE_ID"
+ENV_COMMAND_RETRIES = "CRYOSPARC_COMMAND_RETRIES"
+ENV_COMMAND_RETRY_SECONDS = "CRYOSPARC_COMMAND_RETRY_SECONDS"
+DEFAULT_RETRIES = 3
+DEFAULT_RETRY_INTERVAL = 30
+
+
+class CommandClient:
+    """
+    Lightweight client for CryoSPARC's ``command_core`` JSON-RPC service.
+
+    Args:
+        host: Hostname or IP address of the CryoSPARC master. If omitted,
+            ``CRYOSPARC_MASTER_HOSTNAME`` is used, falling back to
+            ``cryosparcm env``.
+        port: command_core port. With the default CryoSPARC base port 39000,
+            command_core is usually 39002. If omitted,
+            ``CRYOSPARC_COMMAND_CORE_PORT`` is used, falling back to
+            ``cryosparcm env``.
+        license_id: CryoSPARC license ID used in the ``License-ID`` header.
+            If omitted, ``CRYOSPARC_LICENSE_ID`` is read from the environment,
+            falling back to ``cryosparcm env``.
+        timeout: Request timeout in seconds.
+        retries: Number of attempts for URL/timeout transport failures.
+        retry_interval: Seconds to sleep between retry attempts.
+
+    Examples:
+        >>> cli = CommandClient(license_id="...")
+        >>> cli.get_system_info()
+        >>> cli.call("get_system_info")
+    """
+
+    def __init__(
+        self,
+        host: Optional[str] = None,
+        port: Optional[int] = None,
+        *,
+        license_id: Optional[str] = None,
+        timeout: int = 300,
+        retries: Optional[int] = None,
+        retry_interval: Optional[int] = None,
+    ) -> None:
+        env = get_env(
+            (
+                ENV_MASTER_HOSTNAME,
+                ENV_COMMAND_CORE_PORT,
+                ENV_LICENSE_ID,
+                ENV_COMMAND_RETRIES,
+                ENV_COMMAND_RETRY_SECONDS,
+            )
+        )
+
+        if host is None:
+            host = get_env_value(env, ENV_MASTER_HOSTNAME)
+        if port is None:
+            port_value = get_env_value(env, ENV_COMMAND_CORE_PORT)
+            if port_value is not None:
+                port = int(port_value)
+        if license_id is None:
+            license_id = get_env_value(env, ENV_LICENSE_ID)
+        if retries is None:
+            retries = get_env_int(env, ENV_COMMAND_RETRIES, DEFAULT_RETRIES)
+        if retry_interval is None:
+            retry_interval = get_env_int(env, ENV_COMMAND_RETRY_SECONDS, DEFAULT_RETRY_INTERVAL)
+
+        if host is None:
+            raise CommandError(
+                f"Missing {ENV_MASTER_HOSTNAME}; pass host explicitly or make it available via cryosparcm env"
+            )
+        if port is None:
+            raise CommandError(
+                f"Missing {ENV_COMMAND_CORE_PORT}; pass port explicitly or make it available via cryosparcm env"
+            )
+
+        self.service = SERVICE_NAME
+        self.host = host
+        self.port = port
+        self._url = f"http://{host}:{port}"
+        self._timeout = timeout
+        self._retries = retries
+        self._retry_interval = retry_interval
+        self._endpoints: List[str] = []
+
+        self._headers = {"Originator": "client"}
+        if license_id:
+            self._headers["License-ID"] = license_id
+
+        self.reload()
+
+    @property
+    def base_url(self) -> str:
+        """Base URL for the command_core service, e.g. ``http://localhost:39002``."""
+
+        return self._url
+
+    @property
+    def endpoints(self) -> List[str]:
+        """Names of JSON-RPC endpoints discovered via ``system.describe``."""
+
+        return list(self._endpoints)
+
+    def call(self, method: str, *args: Any, **kwargs: Any) -> Any:
+        """
+        Call a JSON-RPC method exposed by command_core.
+
+        Positional arguments are encoded as a JSON-RPC params array. Keyword
+        arguments are encoded as a params object. Mixing both is rejected to
+        avoid ambiguous calls.
+        """
+
+        if args and kwargs:
+            raise TypeError("Use either positional args or keyword args, not both")
+
+        params: Any = kwargs if kwargs else list(args)
+        payload = {
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params,
+            "id": str(uuid.uuid4()),
+        }
+
+        try:
+            response = self.json_request("/api", data=payload)
+        except CommandError as err:
+            raise CommandError(
+                f'Encountered transport error from JSON-RPC method "{method}" with params {params}',
+                url=err.url or self._url,
+                code=err.code,
+                data=err.data,
+            ) from err
+
+        if not response:
+            raise CommandError(
+                f'JSON response not received from JSON-RPC method "{method}" with params {params}',
+                url=self._url,
+            )
+
+        if "error" in response:
+            error = response["error"]
+            raise CommandError(
+                f'Encountered {error.get("name", "Error")} from JSON-RPC method "{method}" with params {params}:\n'
+                f"{format_server_error(error)}",
+                url=self._url,
+                code=error.get("code", 500),
+                data=error.get("data"),
+            )
+
+        return response.get("result")
+
+    def reload(self) -> None:
+        """
+        Refresh the list of JSON-RPC endpoints and attach them as methods.
+        """
+
+        system = self.call("system.describe")
+        procs = system.get("procs", []) if isinstance(system, dict) else []
+        self._endpoints = [proc["name"] for proc in procs if isinstance(proc, dict) and "name" in proc]
+
+        for endpoint in self._endpoints:
+            setattr(self, endpoint, self._make_rpc_method(endpoint))
+
+    def __call__(self) -> None:
+        """Alias for ``reload()`` for compatibility with CryoSPARC's client."""
+
+        self.reload()
+
+    def request(
+        self,
+        path: str = "",
+        *,
+        method: str = "POST",
+        query: Optional[Dict[str, Any]] = None,
+        data: Optional[bytes] = None,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> bytes:
+        """
+        Make a raw HTTP request to command_core and return response bytes.
+
+        This is mostly a low-level escape hatch. For JSON-RPC calls, prefer
+        ``call(...)``.
+        """
+
+        request_url = self._url + path
+        if query:
+            request_url += "?" + urlencode(query)
+
+        request_headers = dict(self._headers)
+        if headers:
+            request_headers.update(headers)
+
+        last_reason = "<unknown>"
+        last_code = 500
+        last_data: Any = None
+
+        for attempt in range(1, self._retries + 1):
+            req = Request(request_url, data=data, headers=request_headers, method=method)
+            try:
+                with urlopen(req, timeout=self._timeout) as response:
+                    return response.read()
+            except HTTPError as error:
+                last_code = error.code
+                last_reason = (
+                    f"HTTP Error {error.code} {error.reason}; "
+                    f"please check cryosparcm log {self.service} for additional information."
+                )
+                last_data = error.read() if error.readable() else None
+                if last_data and error.headers.get_content_type() == "application/json":
+                    try:
+                        last_data = json.loads(last_data)
+                    except (TypeError, ValueError):
+                        pass
+                raise CommandError(last_reason, url=request_url, code=last_code, data=last_data)
+            except URLError as error:
+                last_reason = f"URL Error {error.reason}"
+                if attempt < self._retries:
+                    warn(
+                        f"*** {type(self).__name__}: ({request_url}) {last_reason}, "
+                        f"attempt {attempt} of {self._retries}. Retrying in {self._retry_interval} seconds",
+                        stacklevel=2,
+                    )
+                    time.sleep(self._retry_interval)
+            except (TimeoutError, socket.timeout):
+                last_reason = f"Timeout Error after {self._timeout} seconds"
+                if attempt < self._retries:
+                    warn(
+                        f"*** {type(self).__name__}: command ({request_url}) did not reply within "
+                        f"timeout of {self._timeout} seconds, attempt {attempt} of {self._retries}. "
+                        f"Retrying in {self._retry_interval} seconds",
+                        stacklevel=2,
+                    )
+                    time.sleep(self._retry_interval)
+
+        raise CommandError(last_reason, url=request_url, code=last_code, data=last_data)
+
+    def json_request(
+        self,
+        path: str = "",
+        *,
+        query: Optional[Dict[str, Any]] = None,
+        data: Any = None,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> Any:
+        """
+        Send JSON request data and decode a JSON response.
+        """
+
+        request_headers = {"Content-Type": "application/json"}
+        if headers:
+            request_headers.update(headers)
+
+        body = json.dumps(data).encode("utf-8")
+        raw = self.request(path, method="POST", query=query, data=body, headers=request_headers)
+        return json.loads(raw.decode("utf-8"))
+
+    def _make_rpc_method(self, method: str):
+        def rpc_method(*args: Any, **kwargs: Any) -> Any:
+            return self.call(method, *args, **kwargs)
+
+        rpc_method.__name__ = method.replace(".", "_")
+        rpc_method.__doc__ = f'Dynamically generated wrapper for JSON-RPC method "{method}".'
+        return rpc_method
+
+
+def format_server_error(error: Dict[str, Any]) -> str:
+    """
+    Format a JSON-RPC error object returned by CryoSPARC.
+    """
+
+    message = error["message"] if "message" in error else str(error)
+    data = error.get("data")
+    if data:
+        if isinstance(data, dict) and "traceback" in data:
+            message += "\n" + data["traceback"]
+        else:
+            message += "\n" + str(data)
+    return message

--- a/src/cryosieve/autocsparc/dryrun.py
+++ b/src/cryosieve/autocsparc/dryrun.py
@@ -1,0 +1,18 @@
+from ..logger import logger
+
+
+class DryRunClient:
+    def __init__(self):
+        self.job_count = 0
+
+    def call(self, method, *args, **kwargs):
+        logger.debug(f'Dry run: skip CryoSPARC JSON-RPC call {method}')
+
+    def __getattr__(self, method):
+        def dry_run_method(*args, **kwargs):
+            return self.call(method, *args, **kwargs)
+        return dry_run_method
+
+    def make_job(self, *args, **kwargs):
+        self.job_count += 1
+        return f'_J{self.job_count}'

--- a/src/cryosieve/autocsparc/env.py
+++ b/src/cryosieve/autocsparc/env.py
@@ -1,0 +1,95 @@
+"""
+Utilities for discovering environment settings.
+
+This module first reads the current process environment. If any requested
+variables are missing, it falls back to ``cryosparcm env`` and parses its
+shell-style output, for example::
+
+    export "CRYOSPARC_COMMAND_CORE_PORT=39102"
+"""
+
+import os
+import re
+import subprocess
+from typing import Dict, Iterable, Mapping, Optional
+
+
+ENV_COMMAND = ("cryosparcm", "env")
+ENV_EXPORT_RE = re.compile(r'^export\s+"([^=]+)=(.*)"\s*$')
+
+
+def parse_env_output(output: str) -> Dict[str, str]:
+    """
+    Parse output produced by ``cryosparcm env``.
+    """
+
+    env: Dict[str, str] = {}
+    for line in output.splitlines():
+        match = ENV_EXPORT_RE.match(line.strip())
+        if match:
+            key, value = match.groups()
+            env[key] = value
+    return env
+
+
+def read_cryosparcm_env() -> Dict[str, str]:
+    """
+    Execute ``cryosparcm env`` and return parsed variables.
+
+    If ``cryosparcm`` is unavailable or exits with an error, an empty mapping is
+    returned. This keeps environment discovery best-effort and lets the caller
+    fall back to hard-coded defaults when necessary.
+    """
+
+    try:
+        completed = subprocess.run(
+            ENV_COMMAND,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return {}
+    return parse_env_output(completed.stdout)
+
+
+def get_env(required_keys: Iterable[str]) -> Dict[str, str]:
+    """
+    Return environment values for the requested keys.
+
+    Values already present in ``os.environ`` take precedence. ``cryosparcm env``
+    is only executed if one or more requested keys are missing.
+    """
+
+    keys = list(required_keys)
+    env = {key: os.environ[key] for key in keys if key in os.environ}
+    missing = [key for key in keys if key not in env]
+    if missing:
+        fallback = read_cryosparcm_env()
+        for key in missing:
+            if key in fallback:
+                env[key] = fallback[key]
+    return env
+
+
+def get_env_value(env: Mapping[str, str], key: str, default: Optional[str] = None) -> Optional[str]:
+    """
+    Return ``env[key]`` unless it is missing or empty.
+    """
+
+    value = env.get(key)
+    return value if value else default
+
+
+def get_env_int(env: Mapping[str, str], key: str, default: int) -> int:
+    """
+    Return an integer environment value, or ``default`` if missing or invalid.
+    """
+
+    value = get_env_value(env, key)
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except ValueError:
+        return default

--- a/src/cryosieve/autocsparc/errors.py
+++ b/src/cryosieve/autocsparc/errors.py
@@ -1,0 +1,29 @@
+"""
+Error types used by autocsparc.
+"""
+
+from typing import Any
+
+
+class CommandError(Exception):
+    """
+    Raised when a request to CryoSPARC command_core fails.
+
+    Attributes:
+        reason: Human-readable failure reason.
+        url: URL that was requested.
+        code: HTTP or JSON-RPC error code when available.
+        data: Optional response data attached to the error.
+    """
+
+    reason: str
+    url: str
+    code: int
+    data: Any
+
+    def __init__(self, reason: str, *args: object, url: str = "", code: int = 500, data: Any = None) -> None:
+        self.reason = reason
+        self.url = url
+        self.code = code
+        self.data = data
+        super().__init__(f"*** ({url}, code {code}) {reason}", *args)

--- a/src/cryosieve/cs_refine.py
+++ b/src/cryosieve/cs_refine.py
@@ -1,22 +1,13 @@
 import argparse
-import os
-import subprocess
 import sys
 from pathlib import Path
 from threading import Lock
-
-try:
-    from .logger import logger
-except ImportError:
-    # Ensure running this script in $(cryosparcm env)
-    sys.path.insert(0, str(Path(__file__).absolute().parent.parent))
-    from cryosieve.logger import logger
+from .logger import logger
 
 cryosparc_job_total = None
 cryosparc_jobs_generated = 0
 cryosparc_jobs_enqueued = 0
 cryosparc_jobs_completed = 0
-dry_run = False
 lock = Lock()
 
 def parse_argument():
@@ -43,105 +34,27 @@ def parse_argument():
         exit()
     return parser.parse_args()
 
-class DryRunClient:
-    def __init__(self):
-        self.job_count = 0
-
-    def make_job(self, **kwargs):
-        self.job_count += 1
-        return f'_J{self.job_count}'
-
-    def enqueue_job(self, project_uid, job_id, lane, user_id):
-        pass
-
-    def get_job_status(self, project_uid, job_id):
-        return 'completed'
-
-    def get_job_streamlog(self, project_uid, job_id):
-        return [
-            {'text': 'Split A has 500 particles'},
-            {'text': 'Split B has 500 particles'},
-            {'text': 'Using Filter Radius: 100 (3.00A)'},
-            {'text': 'Estimated Bfactor: -100.0'},
-        ]
-
-    def get_project_dir_abs(self, project_uid):
-        return str(Path.cwd())
-
-    def get_job_result(self, project_uid, result):
-        return {'metafile': f'dry_run_{result}.cs'}
-
-def load_dry_run(args):
-    global client, user_id, project_uid, workspace_uid, lane, dry_run
-
-    client = DryRunClient()
-    user_id = args.user
-    project_uid = args.project
-    workspace_uid = args.workspace
-    lane = args.lane
-    dry_run = True
-    logger.info('Dry run enabled: simulate CryoSPARC jobs without connecting to CryoSPARC')
-
-def load_cryosparc_env():
-    try:
-        from cryosparc_compute.client import CommandClient  # noqa: F401
-        return
-    except ImportError:
-        pass
-
-    try:
-        result = subprocess.run(
-            ['bash', '-lc', 'cryosparcm env'],
-            check = True,
-            stdout = subprocess.PIPE,
-            stderr = subprocess.PIPE,
-            text = True
-        )
-    except FileNotFoundError as exc:
-        raise RuntimeError('bash is required to load CryoSPARC environment') from exc
-    except subprocess.CalledProcessError as exc:
-        detail = (exc.stderr or exc.stdout or '').strip()
-        message = 'failed to load CryoSPARC environment with `cryosparcm env`'
-        if detail:
-            message += f': {detail}'
-        raise RuntimeError(message) from exc
-
-    state = parse_shell_python_state(result.stdout)
-    os.environ.update(state.get('env', {}))
-    for path in state.get('sys_path', []):
-        if path and path not in sys.path:
-            sys.path.append(path)
-
-def parse_shell_python_state(script):
-    command = 'eval "$1" && python - <<\'PY\'\nimport json\nimport os\nimport sys\nprint(json.dumps({"env": dict(os.environ), "sys_path": sys.path}))\nPY'
-    result = subprocess.run(
-        ['bash', '-c', command, 'cryosparcm-env', script],
-        check = True,
-        stdout = subprocess.PIPE,
-        stderr = subprocess.PIPE,
-        text = True
-    )
-    return __import__('json').loads(result.stdout)
-
 def load_cryosparc(args):
-    load_cryosparc_env()
-    from cryosparc_compute.client import CommandClient
-    global host, port, client, user_id, project_uid, workspace_uid, lane
+    if args.dry_run:
+        from .autocsparc import DryRunClient
+        client = DryRunClient()
+        logger.info('Dry run enabled: simulate CryoSPARC jobs without connecting to CryoSPARC')
+        return client, args.user
+    else:
+        from .autocsparc import CommandClient
+        client = CommandClient()
+        user_id = client.get_id_by_email(args.user)
+        return client, user_id
 
-    host = os.environ['CRYOSPARC_MASTER_HOSTNAME']
-    port = os.environ['CRYOSPARC_COMMAND_CORE_PORT']
-    client = CommandClient(host = host, port = port)
-    user_id = client.get_id_by_email(args.user)
-    project_uid = args.project
-    workspace_uid = args.workspace
-    lane = args.lane
-
-def enqueue_and_wait(local_lane, **kwargs):
+def enqueue_and_wait(session, lane, **kwargs):
     from time import sleep
     from random import uniform
 
-    global cryosparc_jobs_generated, cryosparc_jobs_enqueued, cryosparc_jobs_completed
+    global cryosparc_jobs_generated, cryosparc_jobs_enqueued, cryosparc_jobs_completed, lock
     job_type = kwargs.get('job_type', 'unknown')
+    client, user_id, project_uid, workspace_uid, _ = session
+    from .autocsparc import DryRunClient
+    dry_run = isinstance(client, DryRunClient)
 
     with lock:
         job_id = client.make_job(
@@ -153,13 +66,17 @@ def enqueue_and_wait(local_lane, **kwargs):
         cryosparc_jobs_generated += 1
         logger.info(f'[{cryosparc_jobs_generated}/{cryosparc_job_total}] Generated CryoSPARC job {job_id} ({job_type})')
 
-        client.enqueue_job(project_uid, job_id, local_lane, user_id)
+        client.enqueue_job(project_uid, job_id, lane, user_id)
         cryosparc_jobs_enqueued += 1
-        logger.info(f'[{cryosparc_jobs_enqueued}/{cryosparc_job_total}] Enqueued CryoSPARC job {job_id} ({job_type}, lane={local_lane})')
+        logger.info(f'[{cryosparc_jobs_enqueued}/{cryosparc_job_total}] Enqueued CryoSPARC job {job_id} ({job_type}, lane={lane})')
+
+        if dry_run:
+            cryosparc_jobs_completed += 1
+            logger.info(f'[{cryosparc_jobs_completed}/{cryosparc_job_total}] Dry run: skip waiting for CryoSPARC job {job_id} ({job_type})')
+            return job_id
 
     while True:
-        if not dry_run:
-            sleep(uniform(20, 40))
+        sleep(uniform(20, 40))
         with lock:
             job_status = client.get_job_status(project_uid, job_id)
             if job_status == 'completed':
@@ -170,36 +87,50 @@ def enqueue_and_wait(local_lane, **kwargs):
                 logger.error(f'[{cryosparc_jobs_completed}/{cryosparc_job_total}] CryoSPARC job {job_id} {job_status} ({job_type})')
                 raise RuntimeError(f'Job {job_id} is {job_status}')
 
-def import_particles(particle_meta_path):
+def import_particles(session, meta_path, data_dir):
     import_job_id = enqueue_and_wait(
-        None,
+        session,
+        lane = None,
         job_type = 'import_particles',
         params = {
-            'particle_meta_path' : particle_meta_path,
-            'particle_blob_path' : str(Path(args.directory).absolute())
+            'particle_meta_path' : meta_path,
+            'particle_blob_path' : data_dir
         }
     )
     return import_job_id
 
-def abinit(import_particles_job_id):
+def import_volume(session, ref):
+    import_ref_job_id = enqueue_and_wait(
+        session,
+        lane = None,
+        job_type = 'import_volumes',
+        params = {
+            'volume_blob_path' : ref
+        }
+    )
+    return import_ref_job_id
+
+def abinit(session, particle):
     abinit_job_id = enqueue_and_wait(
-        lane,
+        session,
+        lane = session[4],
         job_type = 'homo_abinit',
         input_group_connects = {
-            'particles': f'{import_particles_job_id}.imported_particles'
+            'particles': particle
         }
     )
     return abinit_job_id
 
-def refine(particle, volume):
+def refine(session, particle, volume, ini_high, sym, resplit, nu):
     params = {
-        'refine_symmetry' : args.sym,
-        'refine_gs_resplit' : args.resplit
+        'refine_symmetry' : sym,
+        'refine_gs_resplit' : resplit
     }
-    if args.ini_high is not None: params['refine_res_init'] = args.ini_high
+    if ini_high is not None: params['refine_res_init'] = ini_high
     refine_job_id = enqueue_and_wait(
-        lane,
-        job_type = 'nonuniform_refine_new' if args.nu else 'homo_refine_new',
+        session,
+        lane = session[4],
+        job_type = 'nonuniform_refine_new' if nu else 'homo_refine_new',
         params = params,
         input_group_connects = {
             'particles' : particle,
@@ -208,14 +139,15 @@ def refine(particle, volume):
     )
     return refine_job_id
 
-def local_refine(refine_job_id):
+def local_refine(session, refine_job_id, sym, min_angular_step):
     local_refine_job_id = enqueue_and_wait(
-        lane,
+        session,
+        lane = session[4],
         job_type = 'new_local_refine',
         params = {
-            'refine_symmetry' : args.sym,
+            'refine_symmetry' : sym,
             'use_alignment_prior' : True,
-            'min_angular_step' : args.min_angular_step
+            'min_angular_step' : min_angular_step
         },
         input_group_connects = {
             'particles' : f'{refine_job_id}.particles',
@@ -225,8 +157,9 @@ def local_refine(refine_job_id):
     )
     return local_refine_job_id
 
-def parse_result(refine_job_id):
+def parse_result(session, refine_job_id):
     import re
+    client, _, project_uid, _, _ = session
 
     with lock: streamlog = client.get_job_streamlog(project_uid, refine_job_id)
     text_list = [entry['text'].strip() for entry in streamlog if 'text' in entry]
@@ -244,46 +177,11 @@ def parse_result(refine_job_id):
     with lock: alignment3D_path = client.get_project_dir_abs(project_uid) + '/' + client.get_job_result(project_uid, f'{refine_job_id}.particles.alignments3D')['metafile']
     return [num_A + num_B, resolution, bfactor, alignment3D_path]
 
-def check_results(results, info = None):
-    if info is not None:
+def check_results(results, info = None, dry_run = False):
+    if info is not None and not dry_run:
         logger.info(f'{info} {results}')
     if any(result is None for result in results):
         raise RuntimeError('Error occurred during execution')
-
-def main():
-    args = parse_argument()
-    input_path = ' '.join(f'"{file}"' for file in args.i)
-    command = ' '.join([
-        'eval $(cryosparcm env) && python',
-        str(Path(__file__).absolute()),
-        f'--i {input_path}',
-        f'--directory "{args.directory}"' if args.directory else '',
-        f'--o "{args.o}"' if args.o is not None else '',
-        f'--sym {args.sym}',
-        f'--ref "{args.ref}"' if args.ref is not None else '',
-        f'--ini_high {args.ini_high}' if args.ini_high is not None else '',
-        f'--repeat {args.repeat}',
-        f'--user {args.user}',
-        f'--project {args.project}',
-        f'--workspace {args.workspace}',
-        f'--lane {args.lane}',
-        '--nu' if args.nu else '',
-        '--local' if args.local else '',
-        '--resplit' if args.resplit else '',
-        '--dry_run' if args.dry_run else '',
-        f'--workers {args.workers}' if args.workers is not None else '',
-    ])
-    import subprocess
-    subprocess.run(command, shell = True)
-
-def calculate_cryosparc_job_counts(num_particle_meta_paths):
-    return {
-        'import_particles' : num_particle_meta_paths,
-        'import_volumes' : 1 if args.ref is not None else 0,
-        'ab_inito' : 0 if args.ref is not None else num_particle_meta_paths,
-        'refine' : num_particle_meta_paths * args.repeat,
-        'local_refine' : num_particle_meta_paths * args.repeat if args.local else 0
-    }
 
 def parse_meta_paths(paths):
     particle_meta_paths = []
@@ -302,22 +200,30 @@ def parse_meta_paths(paths):
             raise RuntimeError(f'"{path}" is not a star or txt file')
     return particle_meta_paths
 
-if __name__ == '__main__':
-    args = parse_argument()
-    if args.dry_run:
-        load_dry_run(args)
-    else:
-        load_cryosparc(args)
+def process(args):
+    client, user_id = load_cryosparc(args)
+    session = (client, user_id, args.project, args.workspace, args.lane)
 
-    # Check args.
+    # Check args
     particle_meta_paths = parse_meta_paths(args.i)
     if not Path(args.directory).is_dir():
         raise FileNotFoundError(f'"{args.directory}" is not a directory')
+    particle_data_dir = str(Path(args.directory).absolute())
     if args.ref is not None:
         if not Path(args.ref).is_file():
             raise FileNotFoundError(f'"{args.ref}" does not exist')
+        ref = str(Path(args.ref).absolute())
+    else:
+        ref = None
 
-    cryosparc_job_counts = calculate_cryosparc_job_counts(len(particle_meta_paths))
+    global cryosparc_job_total
+    cryosparc_job_counts = {
+        'import_particles' : len(particle_meta_paths),
+        'import_volumes' : 1 if ref is not None else 0,
+        'ab_inito' : 0 if ref is not None else len(particle_meta_paths),
+        'refine' : len(particle_meta_paths) * args.repeat,
+        'local_refine' : len(particle_meta_paths) * args.repeat if args.local else 0
+    }
     cryosparc_job_total = sum(cryosparc_job_counts.values())
     logger.info(
         f'Planned CryoSPARC jobs: total={cryosparc_job_total}, '
@@ -330,55 +236,53 @@ if __name__ == '__main__':
         f'ref={args.ref is not None}, local={args.local}'
     )
 
-    # Setup.
+    # Setup
     from concurrent.futures import ThreadPoolExecutor
     pool = ThreadPoolExecutor() if args.workers is None else ThreadPoolExecutor(max_workers = args.workers)
 
-    # Import particles.
-    import_particles_tasks = [pool.submit(import_particles, particle_meta_path) for particle_meta_path in particle_meta_paths]
+    # Import particles
+    import_particles_tasks = [pool.submit(import_particles, session, particle_meta_path, particle_data_dir) for particle_meta_path in particle_meta_paths]
     import_particles_job_ids = [task.result() for task in import_particles_tasks]
-    check_results(import_particles_job_ids, 'Import particles:')
+    check_results(import_particles_job_ids, 'Import particles:', args.dry_run)
     particles = [f'{import_particles_job_id}.imported_particles' for import_particles_job_id in import_particles_job_ids]
 
-    # Import volumes, if ref is given.
-    if args.ref is not None:
-        import_ref_job_id = enqueue_and_wait(
-            None,
-            job_type = 'import_volumes',
-            params = {
-                'volume_blob_path' : str(Path(args.ref).absolute())
-            }
-        )
-        check_results([import_ref_job_id], 'Imported reference maps:')
+    # Import volumes, if ref is given
+    if ref is not None:
+        import_ref_job_id = import_volume(session, ref)
+        check_results([import_ref_job_id], 'Imported reference maps:', args.dry_run)
         volumes = [f'{import_ref_job_id}.imported_volume_1'] * len(particles)
-    # Otherwise, use ab-initio reconstruction.
+
+    # Otherwise, use ab-initio reconstruction
     else:
-        abinit_tasks = [pool.submit(abinit, import_particles_job_id) for import_particles_job_id in import_particles_job_ids]
+        abinit_tasks = [pool.submit(abinit, session, particle) for particle in particles]
         abinit_job_ids = [task.result() for task in abinit_tasks]
-        check_results(abinit_job_ids, 'Ab-initio reconstruction:')
+        check_results(abinit_job_ids, 'Ab-initio reconstruction:', args.dry_run)
         volumes = [f'{abinit_job_id}.volume_class_0' for abinit_job_id in abinit_job_ids]
 
-    # Homogenous / non-uniform refinement.
+    # Homogenous / non-uniform refinement
     from itertools import product
-    refine_tasks = [pool.submit(refine, particle, volume) for (particle, volume), _ in product(zip(particles, volumes), range(args.repeat))]
+    refine_tasks = [pool.submit(refine, session, particle, volume, args.ini_high, args.sym, args.resplit, args.nu) for (particle, volume), _ in product(zip(particles, volumes), range(args.repeat))]
     refine_job_ids = [task.result() for task in refine_tasks]
-    check_results(refine_job_ids, 'Homogeneous / Non-uniform refinement:')
+    check_results(refine_job_ids, 'Homogeneous / Non-uniform refinement:', args.dry_run)
 
-    # Local refinement.
+    # Local refinement
     if args.local:
-        refine_tasks = [pool.submit(local_refine, refine_job_id) for refine_job_id in refine_job_ids]
+        refine_tasks = [pool.submit(local_refine, session, refine_job_id, args.sym, args.min_angular_step) for refine_job_id in refine_job_ids]
         refine_job_ids = [task.result() for task in refine_tasks]
-        check_results(refine_job_ids, 'Local refinement:')
+        check_results(refine_job_ids, 'Local refinement:', args.dry_run)
 
-    # Get results.
-    parse_result_tasks = [pool.submit(parse_result, refine_job_id) for refine_job_id in refine_job_ids]
+    if args.dry_run:
+        pool.shutdown()
+        logger.info('Dry run: skip result parsing and summary CSV output')
+        return
+
+    # Get results
+    parse_result_tasks = [pool.submit(parse_result, session, refine_job_id) for refine_job_id in refine_job_ids]
     results = [task.result() for task in parse_result_tasks]
     check_results(results)
-
-    # Shutdown.
     pool.shutdown()
 
-    # Save results.
+    # Save results
     import csv
     with open(args.o, 'w') as csvfile:
         csvwriter = csv.writer(csvfile)
@@ -386,3 +290,10 @@ if __name__ == '__main__':
         for i, result in enumerate(results):
             particle_meta_path = particle_meta_paths[i // args.repeat]
             csvwriter.writerow([particle_meta_path] + result)
+
+def main():
+    args = parse_argument()
+    process(args)
+
+if __name__ == '__main__':
+    main()

--- a/src/cryosieve/cs_rhbfactor.py
+++ b/src/cryosieve/cs_rhbfactor.py
@@ -1,5 +1,4 @@
 import argparse
-import shlex
 import sys
 from .logger import logger
 
@@ -103,32 +102,33 @@ def main():
                     print(tmpfile, file = lst_file)
 
     # Call cryosieve-csrefine to estimate resolutions.
-    command = ' '.join([
-        shlex.quote(sys.executable),
-        '-m cryosieve.cs_refine',
-        f'--i {str(list_path)}',
-        f'--directory "{args.directory}"' if args.directory is not None else '',
-        f'--o {str(rawpath)}',
-        f'--sym {args.sym}',
-        f'--ref "{args.ref}"' if args.ref is not None else '',
-        f'--ini_high {args.ini_high}' if args.ini_high is not None else '',
-        f'--user {args.user}',
-        f'--project {args.project}',
-        f'--workspace {args.workspace}',
-        f'--lane {args.lane}',
-        '--nu' if args.nu else '',
-        '--resplit' if args.resplit else '',
-        '--dry_run' if args.dry_run else '',
-        f'--workers {args.workers}' if args.workers is not None else '',
-    ])
-    logger.info(f'Starting cryosieve-csrefine subprocess for RH-factor estimation: inputs={num_particle_sets}, raw output={rawpath}')
+    from .cs_refine import process as refine_process
+    refine_args = argparse.Namespace(
+        i = [str(list_path)],
+        directory = args.directory,
+        o = str(rawpath),
+        sym = args.sym,
+        ref = args.ref,
+        ini_high = args.ini_high,
+        repeat = 1,
+        user = args.user,
+        project = args.project,
+        workspace = args.workspace,
+        lane = args.lane,
+        nu = args.nu,
+        local = False,
+        min_angular_step = 0.01,
+        resplit = args.resplit,
+        workers = args.workers,
+        dry_run = args.dry_run,
+    )
+    logger.info(f'Starting cryosieve-csrefine for RH-factor estimation: inputs={num_particle_sets}, raw output={rawpath}')
+    refine_process(refine_args)
+    logger.info(f'Completed cryosieve-csrefine for RH-factor estimation: inputs={num_particle_sets}, raw output={rawpath}')
 
-    import subprocess
-    process = subprocess.run(command, shell = True)
-    if process.returncode:
-        logger.error(f'cryosieve-csrefine subprocess failed for RH-factor estimation: returncode={process.returncode}')
-        raise RuntimeError('Error in running cryosieve-csrefine')
-    logger.info(f'Completed cryosieve-csrefine subprocess for RH-factor estimation: inputs={num_particle_sets}, raw output={rawpath}')
+    if args.dry_run:
+        logger.info('Dry run: skip RH-curve fitting and summary CSV output')
+        return
 
     # Fit RH-curve.
     import numpy as np


### PR DESCRIPTION
不需要事先进入cryosparcm env就可以直接使用的CommandClient，放入autocsparc子包。同时也模拟了一个DryRunClient，大幅简化了csrefine和csrhbfactor的代码逻辑，现在不需要各种奇怪的子进程跳来跳去了。